### PR TITLE
add Docker for crystfel

### DIFF
--- a/docker/nersc/build_docker_crystfel.sh
+++ b/docker/nersc/build_docker_crystfel.sh
@@ -1,0 +1,1 @@
+docker build -t crystfel -f docker/Dockerfile.crystfel .

--- a/docker/nersc/docker/Dockerfile.crystfel
+++ b/docker/nersc/docker/Dockerfile.crystfel
@@ -1,0 +1,31 @@
+
+FROM slaclcls/lcls-py2
+LABEL maintainer="Chuck Yoon <yoon82@stanford.edu>"
+
+#-------------------------------------------------------------------------------
+RUN \
+    apt-get --yes install                                                      \
+        build-essential                                                        \
+        libhdf5-dev                                                            \
+        libgsl-dev                                                             \
+        libgtk2.0-dev                                                          \
+        libcairo2-dev                                                          \
+        libpango1.0-dev                                                        \
+        libgdk-pixbuf2.0-dev                                                   \
+        libfftw3-dev                                                           \
+        libcbf-dev                                                             \
+        libncurses5-dev                                                        \
+        libpng-dev                                                             \
+        libtiff5-dev                                                           \
+        cmake
+
+# Download CrystFEL v0.8.0 and install under /img
+# crystfel-0.9.0 requires cmake v3.12+ (not available in apt as of 6/8/20)     
+# which reulsts in CMP0074 error. It may also require "apt install flex bison" 
+
+WORKDIR /img
+RUN wget https://www.desy.de/~twhite/crystfel/crystfel-0.8.0.tar.gz &&         \
+         tar -xzf crystfel-0.8.0.tar.gz &&                                     \
+         cd crystfel-0.8.0 &&                                                  \
+         mkdir build && cd build && cmake .. && make install
+


### PR DESCRIPTION
Notes:
We will keep/maintain psana1 and psana2 docker scripts here as a single entity (for now)
We will have clearer naming convention to distinguish psana1 and psana2 (later)
I will install xgandalf indexing method